### PR TITLE
Remove identity scope from docs

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -36,7 +36,6 @@ Users configure the integration by providing an API key obtained from Heroku:
 **Please Note**: The integration currently requires a Heroku Enterprise account
 and the following OAuth scopes:
 
-- `identity`
 - `read`
 
 Optional OAuth scopes:


### PR DESCRIPTION
I tested these APIs locally, and the `identity` scope in isolation did not allow access to any of this integration's API endpoints. The `read` scope gets everything except team members.