### PR TITLE
INT-2740 - Updating documentation around 403 add-on errors

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,12 @@ etc.
 Once you've created your account, you'll need to generate an API Key to access
 the Heroku API.
 
+NOTE: The account used to generate the API key will dictate what permissions it
+has. For full access to all available data, an account with the `admin` role
+should be used. Using an account with the `member` role will be able to pull in
+most data, but currently application add-on information is only available using
+the `admin` role.
+
 1. Visit <https://dashboard.heroku.com/account/applications> and click
    `Create authorization`.
    ![Heroku Authorizations Page](./images/heroku-authorizations.png)

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -43,6 +43,12 @@ Optional OAuth scopes:
 - `global`
   - Allows for fetching members of a Heroku team
 
+The account used to generate the API key will dictate what permissions it has.
+For full access to all available data, an account with the `admin` role should
+be used. Using an account with the `member` role will be able to pull in most
+data, but currently application add-on information is only available using the
+`admin` role.
+
 ### In JupiterOne
 
 1. From the configuration **Gear Icon**, select **Integrations**.


### PR DESCRIPTION
Updating documentation to call out that an admin account needs to be used to create the API key for integrations use in order for add-on data to be ingested.